### PR TITLE
Add support for auth and prefix browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Environment variables:
 | `ETCD`      | etcd endpoint                           | `etcd:2379`                                   |
 | `CORS`      | allowed origins                         | `http://localhost:8080,http://localhost:8081` |
 | `EDITABLE`  | set to `1` to enable edit functionality | `0`                                           |
+| `PREFIX`    | only browse keys under a given prefix   | ``                                            |
+| `USERNAME`  | optionally send a username to etcd      | `<empty>`                                     |
+| `PASSWORD`  | optionally send a password to etcd      | `<empty>`                                     |
 
 ## Development environment
 


### PR DESCRIPTION
This PR adds support for authentication (username and password), as well as anchoring K/V browsing to a fixed prefix. 

Use case: etcd cluster with RBAC enabled, with various role -> prefix allowances.